### PR TITLE
UI tweaks for smoother navigation

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -59,10 +59,12 @@ header {
 
 #design-panel {
   background: linear-gradient(135deg, var(--yellow) 0%, var(--orange) 100%);
+  color: #fff;
 }
 
 #programming-panel {
   background: linear-gradient(135deg, var(--blue) 0%, var(--green) 100%);
+  color: #fff;
 }
 
 /* Effets hover des panneaux */
@@ -82,8 +84,8 @@ header {
 }
 
 .panel-button:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+  transform: translateY(-8px);
+  box-shadow: 0 12px 20px rgba(0, 0, 0, 0.3);
 }
 
 .panel-button::after {
@@ -105,7 +107,7 @@ header {
   display: flex;
   justify-content: center;
   gap: 2rem;
-  margin: 3rem 0;
+  margin: 2rem 0;
   padding: 0 2rem;
 }
 .nav-button {
@@ -129,6 +131,12 @@ header {
   transform: translateY(-50%);
 }
 
+.nav-button .button-text {
+  transform: translateX(-0.75rem);
+  opacity: 0;
+  transition: all 0.45s cubic-bezier(0.65, 0, 0.076, 1);
+}
+
 .nav-button.back-button .icon {
   left: 1.5rem;
 }
@@ -143,6 +151,11 @@ header {
 
 .nav-button:hover .icon.arrow {
   transform: translate(0.5rem, -50%);
+}
+
+.nav-button:hover .button-text {
+  transform: translateX(0);
+  opacity: 1;
 }
 
 .nav-button:hover .icon.home {
@@ -181,6 +194,25 @@ header {
   border-color: var(--green);
 }
 
+.form-label {
+  position: absolute;
+  left: 1rem;
+  top: 0.75rem;
+  padding: 0 0.25rem;
+  background: #fff;
+  color: #6b7280;
+  pointer-events: none;
+  transition: all 0.2s ease;
+}
+
+.peer:focus ~ .form-label,
+.peer:not(:placeholder-shown) ~ .form-label {
+  top: -0.6rem;
+  font-size: 0.875rem;
+  background: #fff;
+  color: var(--blue);
+}
+
 .btn-submit {
   background: linear-gradient(135deg, var(--green) 0%, var(--blue) 100%);
   padding: 1rem 2rem;
@@ -206,7 +238,7 @@ header {
   z-index: 10;
 }
 .separator.swirl {
-  background: linear-gradient(to right, #f59e0b, #fdcb91);
+  background: linear-gradient(to right, var(--orange), var(--yellow));
 }
 
 .separator.wave-layers {
@@ -252,21 +284,20 @@ header {
 /* Responsive Design */
 @media (max-width: 768px) {
   header {
-    flex-direction: column;
-    align-items: center;
     position: relative;
+    padding: 1rem;
   }
-  
+
   .logo-container {
-    margin: 1rem 0;
-    order: -1;
+    flex: 1;
+    justify-content: center;
+    margin: 0;
   }
-  
+
   .mobile-menu-toggle {
     position: absolute;
-    right: 1.5rem;
-    top: 1.5rem;
-    margin-left: auto;
+    right: 1rem;
+    top: 1rem;
   }
   
   .nav-buttons {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -143,8 +143,8 @@ function initPanelInteractions() {
     });
   };
 
-  setupPanel(document.getElementById('design-panel'), '/design-projects.html');
-  setupPanel(document.getElementById('programming-panel'), '/coding-projects.html');
+  setupPanel(document.getElementById('design-panel'), '/design-portfolio');
+  setupPanel(document.getElementById('programming-panel'), '/coding-portfolio');
 }
 
 // Smooth Scrolling

--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
 <!-- Works Section -->
 <div id="works-section">
   <div id="design-panel" class="panel slide-in-left">
-    <button onclick="navigateWithAnimation('design-projects.html')" class="panel-button">
+    <button onclick="navigateWithAnimation('/design-portfolio')" class="panel-button">
       Voir les projets de design
       <svg class="icon" viewBox="0 0 24 24">
         <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
@@ -198,7 +198,7 @@
   </div>
   
   <div id="programming-panel" class="panel slide-in-right">
-    <button onclick="navigateWithAnimation('coding-projects.html')" class="panel-button">
+    <button onclick="navigateWithAnimation('/coding-portfolio')" class="panel-button">
       Voir les projets de code
       <svg class="icon" viewBox="0 0 24 24">
         <path d="M8.59,16.58L13.17,12L8.59,7.41L10,6L16,12L10,18L8.59,16.58Z"/>
@@ -217,7 +217,7 @@
       <p class="mb-8 text-white/90">Explorez mes projets techniques, de la conception de sites web aux applications logicielles complexes.</p>
       <button
         class="relative z-10 px-6 py-2 rounded-full font-semibold text-white bg-gradient-to-r from-white/10 via-white/20 to-white/10 hover:from-white hover:to-white hover:text-slate-800 border border-white transition-all duration-300 backdrop-blur-sm shadow-md hover:shadow-lg"
-        onclick="navigateWithAnimation('/coding-projects.html')">
+        onclick="navigateWithAnimation('/coding-portfolio')">
         Voir les projets de code
       </button>
     </div>
@@ -386,8 +386,8 @@
             </div>
           
             <div class="relative">
-              <input type="text" id="name" class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 bg-white text-gray-800 peer" placeholder=" ">
-              <label for="name" class="absolute left-4 top-3 text-gray-500 transition-all duration-200 pointer-events-none px-1 bg-white peer-placeholder-shown:text-base peer-placeholder-shown:text-gray-400 peer-focus:-top-2.5 peer-focus:text-sm peer-focus:text-blue-600 peer-focus:bg-white peer-focus:px-2 peer-not-placeholder-shown:-top-2.5 peer-not-placeholder-shown:text-sm peer-not-placeholder-shown:text-blue-600 peer-not-placeholder-shown:bg-white peer-not-placeholder-shown:px-2">Nom complet</label>
+              <input type="text" id="name" class="form-input peer" placeholder=" ">
+              <label for="name" class="form-label">Nom complet</label>
             </div>
             
               <div class="relative">

--- a/pages/coding-projects.html
+++ b/pages/coding-projects.html
@@ -58,15 +58,15 @@
 
 <div class="flex flex-col md:flex-row justify-between items-center gap-6 mb-8">
     <!-- Back Button (left) with reversed arrow -->
-    <a href="index.html#works-section" class="nav-button learn-more order-1 md:order-1">
+    <button type="button" onclick="window.history.back()" class="nav-button back-button order-1 md:order-1">
         <span class="circle" aria-hidden="true">
             <span class="icon arrow reversed transform rot"></span>
         </span>
         <span class="button-text">Go Back</span>
-    </a>
+    </button>
     
     <!-- Home Button (right) -->
-    <a href="index.html#hero" class="nav-button learn-more home order-2 md:order-3">
+    <a href="/" class="nav-button home-button order-2 md:order-3">
         <span class="circle" aria-hidden="true">
             <span class="icon home"></span>
         </span>

--- a/pages/design-projects.html
+++ b/pages/design-projects.html
@@ -58,15 +58,15 @@
 
 <div class="flex flex-col md:flex-row justify-between items-center gap-6 mb-8">
     <!-- Back Button (left) with reversed arrow -->
-    <a href="index.html#works-section" class="nav-button learn-more order-1 md:order-1">
+    <button type="button" onclick="window.history.back()" class="nav-button back-button order-1 md:order-1">
         <span class="circle" aria-hidden="true">
             <span class="icon arrow reversed transform rot"></span>
         </span>
         <span class="button-text">Go Back</span>
-    </a>
+    </button>
     
     <!-- Home Button (right) -->
-    <a href="index.html#hero" class="nav-button learn-more home order-2 md:order-3">
+    <a href="/" class="nav-button home-button order-2 md:order-3">
         <span class="circle" aria-hidden="true">
             <span class="icon home"></span>
         </span>


### PR DESCRIPTION
## Summary
- adjust panel buttons to link to `/design-portfolio` and `/coding-portfolio`
- make Go Back button use `window.history.back()`
- refine navigation hover effects
- improve contact form labels and inputs
- tweak responsive header layout

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e42d4e6a8833186b6f027b5f606a6